### PR TITLE
fix: dispose AnimationController

### DIFF
--- a/lib/ui/animation_mask/bouncing_mask.dart
+++ b/lib/ui/animation_mask/bouncing_mask.dart
@@ -11,7 +11,7 @@ class BouncingMask extends StatefulWidget {
   });
 
   @override
-  State<StatefulWidget> createState() {
+  State<BouncingMask> createState() {
     return _BouncingMaskState();
   }
 }
@@ -36,5 +36,11 @@ class _BouncingMaskState extends State<BouncingMask>
       child: widget.child,
       position: _offsetAnimation,
     );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
AnimationController needs to be disposed when the widget got disposed in order to release the resources used